### PR TITLE
iOS取不到Info.plist CFBundleDisplayName的异常处理

### DIFF
--- a/server/controllers/app.js
+++ b/server/controllers/app.js
@@ -502,12 +502,15 @@ module.exports = class AppRouter {
 
         var result = fs.readFileSync(fpath.join(__dirname, "..", 'templates') + '/template.plist')
         var template = result.toString();
+        var appName = app.appName
+        if (typeof(appName) == 'undefined' || appName == null || appName == '') {
+            appName = app.bundleName
+        }
         var rendered = mustache.render(template, {
-            appName: app.appName,
+            appName: appName,
             bundleID: app.bundleId,
             versionStr: version.versionStr,
             downloadUrl: url,
-            fileSize: version.size,
             iconUrl: `${config.baseUrl}/${app.icon}`
         });
         ctx.set('Content-Type', 'text/xml; charset=utf-8');

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -201,6 +201,9 @@ function parseIpa(filename) {
             info.bundleId = result.CFBundleIdentifier
             info.bundleName = result.CFBundleName
             info.appName = result.CFBundleDisplayName
+            if (typeof(info.appName) == 'undefined' || info.appName == null || info.appName == '') {
+                info.appName = info.bundleName
+            }
             info.versionStr = result.CFBundleShortVersionString
             info.versionCode = result.CFBundleVersion
             info.iconName = result.CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconName

--- a/server/templates/template.plist
+++ b/server/templates/template.plist
@@ -11,19 +11,20 @@
 					<key>kind</key>
 					<string>software-package</string>
 					<key>url</key>
-          <string>{{{ downloadUrl }}}</string>
-					<key>md5-size</key>
-          <integer>{{{ fileSize }}}</integer>
+					<string>{{{ downloadUrl }}}</string>
 				</dict>
-				 <dict>
-         <key>kind</key>
-         <string>display-image</string>
-         <!-- optional. indicates if icon needs shine effect applied. -->
-         <key>needs-shine</key>
-         <true/>
-         <key>url</key>
-         <string>{{{ iconUrl }}}</string>
-        </dict>
+				<dict>
+					<key>kind</key>
+					<string>display-image</string>
+					<key>url</key>
+					<string>{{{ iconUrl }}}</string>
+				</dict>
+				<dict>
+					<key>kind</key>
+					<string>full-size-image</string>
+					<key>url</key>
+					<string>{{{ iconUrl }}}</string>
+				</dict>
 			</array>
 			<key>metadata</key>
 			<dict>


### PR DESCRIPTION
1、Xcode新建工程的app名称默认使用`CFBundleName `字段，弃用`CFBundleDisplayName`字段，现已针对上传ipa和生成plist文件的接口在`appName`为空时，取`bundleName`。
#123 
2、更新iOS manifest.plist模板。